### PR TITLE
fixed bug in ifft2d when reconstructing discarded modes in elas_geofno_v2.py

### DIFF
--- a/elasticity/elas_geofno_v2.py
+++ b/elasticity/elas_geofno_v2.py
@@ -139,7 +139,13 @@ class SpectralConv2d(nn.Module):
         basis = torch.exp(1j * 2 * np.pi * K).to(device)
 
         # coeff (batch, channels, m1, m2)
-        u_ft2 = u_ft[..., 1:].flip(-1, -2).conj()
+        kx_neg_idx = torch.cat(
+            [
+                torch.zeros(1, dtype=torch.long, device=device),
+                torch.arange(m1 - 1, 0, -1, dtype=torch.long, device=device),
+            ]
+        )
+        u_ft2 = u_ft.index_select(-2, kx_neg_idx)[..., 1:].flip(-1).conj()
         u_ft = torch.cat([u_ft, u_ft2], dim=-1)
 
         # Y (batch, channels, N)


### PR DESCRIPTION
When reconstructing the discarded ky modes in ifft2d, the following line (line 142) is used:

u_ft2 = u_ft[..., 1:].flip(-1, -2).conj()

The stored kx modes are ordered like [0,1,..., N - 1, -N, -(N - 1), ..., -1]. Applying flip(-2) gives [-1, ..., -N, N - 1, ..., 1, 0]. This pairs the 0 mode with -1, 1 mode with -2 etc., which is incorrect and shows up as a central vertical artifact. My proposed edit fixes this error, getting rid of the artifact and leading to a decrease in loss of 15-20% on the datasets tested compared to the original Geo-FNO.

This bug might be present in the Geo-FNOs for other datasets, but as I only worked with elas_geofno_v2.py, I only applied the fix here.